### PR TITLE
fix(parse): support special characters using HTML entities

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,6 +4,7 @@ import type { ONIXMessageRoot } from './interfaces';
 export function parse(body: string): ONIXMessageRoot {
   const parser = new XMLParser({
     ignoreAttributes: false,
+    htmlEntities: true,
     numberParseOptions: {
       hex: false,
       leadingZeros: false,


### PR DESCRIPTION
Set options to the parser from fast-xml-parser to allow for special characters using HTML entities, which were previously being displayed as &#170; etc.